### PR TITLE
[ADD] hr_timesheet_auto_creation / backported from 10.0...

### DIFF
--- a/hr_timesheet_auto_creation/README.rst
+++ b/hr_timesheet_auto_creation/README.rst
@@ -1,0 +1,76 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========================
+HR TimeSheet Auto Creation
+===========================
+
+This module extends the functionality of HR timesheet to automatically
+create the Timesheet Activity report via a cron job.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Have basic modules installed (hr_timesheet_sheet)
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Set system's timezone correct(Administrator>Preferences>Timezone:
+Your location timezone).
+#. Set the user access in read the employee and read/write on
+time sheet(default the user is Administrator, So you can skip this set).
+#. Set the time or frequency as you want in the cron job:
+    1). Click button at top right-hand corner `<User Name> -> About Odoo` and click `Activate the developer mode`
+
+    2). Settings>Technical>Automation>Scheduled Actions>My current TMS:
+        modify the time(`Next Execution Date`) or frequency(`Interval Number` and `Interval Unit`).
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/Elico-Corp/odoo-addons/issues>`_.
+In case of trouble, please check there if your issue has already been reported.
+If you spotted it first, help us smashing it by providing a detailed and welcomed feedback
+
+Credits
+=======
+
+Contributors
+------------
+
+* Kevin Dong <kevin.dong@elico-corp.com>
+* Eric Caudal <eric.caudal@elico-corp.com>
+* Vincent Van Rossem <vincent@coopiteasy.be>
+
+Maintainer
+----------
+
+.. image:: https://www.elico-corp.com/logo.png
+   :alt: Elico Corp
+   :target: https://www.elico-corp.com
+
+This module is maintained by Elico Corporation.
+
+Elico Corp is an innovative actor in China, Hong-Kong and Singapore servicing
+well known international companies and as well as local mid-sized businesses.
+Since 2010, our seasoned Sino-European consultants have been providing full
+range Odoo services:
+
+* Business consultancy for Gap analysis, BPM, operational work-flows review. 
+* Ready-to-use ERP packages aimed at starting businesses.
+* Odoo implementation for manufacturing, international trading, service industry
+  and e-commerce. 
+* Connectors and integration with 3rd party software (Magento, Taobao, Coswin,
+  Joomla, Prestashop, Tradevine etc...).
+* Odoo Support services such as developments, training, maintenance and hosting.
+
+Our headquarters are located in Shanghai with branch in Singapore servicing
+customers from all over Asia Pacific.
+
+Contact information: `Sales <contact@elico-corp.com>`__

--- a/hr_timesheet_auto_creation/__init__.py
+++ b/hr_timesheet_auto_creation/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2016-2017 Elico Corp (https://www.elico-corp.com)
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/hr_timesheet_auto_creation/__openerp__.py
+++ b/hr_timesheet_auto_creation/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# © 2016-2017 Elico Corp (https://www.elico-corp.com)
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "HR TimeSheet Auto Creation",
+    "summary": """
+Automatic Timesheet will add a cron job for create the time sheet.
+    """,
+    "version": "9.0.1.0.0",
+    "category": "Human Resources",
+    "author": "Coop IT Easy SCRLfs, Elico Corp, Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "www.coopiteasy.be",
+    "depends": ["hr_timesheet_sheet"],
+    "data": ["data/hr_timesheet_sheet_cron_job.xml"],
+    "application": True,
+    "installable": True,
+}

--- a/hr_timesheet_auto_creation/data/hr_timesheet_sheet_cron_job.xml
+++ b/hr_timesheet_auto_creation/data/hr_timesheet_sheet_cron_job.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="timesheet_sheet_create_corn_job" model="ir.cron">
+            <field name="name">My current TMS</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">weeks</field>
+            <field name="nextcall" eval="(DateTime.now() +
+            timedelta(days= +(7-DateTime.now().weekday()))).
+            strftime('%Y-%m-%d 05:00:00')"/>
+            <field name="numbercall">-1</field>
+            <field name="active" eval="True"/>
+            <field name="doall" eval="True"/>
+            <field name="model">hr_timesheet_sheet.sheet</field>
+            <field name="function">create_employee_timesheet</field>
+            <field name="args">()</field>
+        </record>
+
+    </data>
+</odoo>

--- a/hr_timesheet_auto_creation/models/__init__.py
+++ b/hr_timesheet_auto_creation/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2016-2017 Elico Corp (https://www.elico-corp.com)
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import hr_timesheet_sheet

--- a/hr_timesheet_auto_creation/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_auto_creation/models/hr_timesheet_sheet.py
@@ -3,9 +3,13 @@
 # Copyright 2019 Coop IT Easy SCRLfs
 #   - Vincent Van Rossem <vincent@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
 from openerp import api, models
 
 from datetime import datetime, timedelta
+
+_logger = logging.getLogger(__name__)
 
 
 class HrTimesheetSheet(models.Model):
@@ -13,6 +17,7 @@ class HrTimesheetSheet(models.Model):
 
     @api.model
     def create_employee_timesheet(self):
+        _logger.info("[hr_timesheet_auto_creation][create_employee_timesheet]")
         employee_obj = self.env["hr.employee"]
         employee_ids = employee_obj.search(
             [("active", "=", True), ("user_id", "!=", False)]
@@ -33,6 +38,11 @@ class HrTimesheetSheet(models.Model):
         for employee_id in employee_ids:
             vals["employee_id"] = employee_id
             self.sudo().create(vals)
+            _logger.info(
+                "[hr_timesheet_auto_creation] hr_timesheet_sheet.sheet created for employee %s"
+                % employee_id
+            )
+
         return True
 
 

--- a/hr_timesheet_auto_creation/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_auto_creation/models/hr_timesheet_sheet.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# © 2016-2017 Elico Corp (https://www.elico-corp.com)
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp import api, models
+
+from datetime import datetime, timedelta
+
+
+class HrTimesheetSheet(models.Model):
+    _inherit = "hr_timesheet_sheet.sheet"
+
+    @api.model
+    def create_employee_timesheet(self):
+        employee_obj = self.env["hr.employee"]
+        employee_ids = employee_obj.search(
+            [("active", "=", True), ("user_id", "!=", False)]
+        ).ids
+        today = datetime.now()
+        monday = today + timedelta(days=-today.weekday())
+        sunday = monday + timedelta(days=+6)
+        # Search for existing timesheet
+        exists_timesheet_records = self.search([("date_to", ">=", monday)])
+        ignore_employee_ids = map(
+            lambda x: x.employee_id.id, exists_timesheet_records
+        )
+        employee_ids = list(set(employee_ids) - set(ignore_employee_ids))
+        vals = {
+            "date_from": monday.strftime("%Y-%m-%d"),
+            "date_to": sunday.strftime("%Y-%m-%d"),
+        }
+        for employee_id in employee_ids:
+            vals["employee_id"] = employee_id
+            self.sudo().create(vals)
+        return True

--- a/hr_timesheet_auto_creation/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_auto_creation/models/hr_timesheet_sheet.py
@@ -34,3 +34,28 @@ class HrTimesheetSheet(models.Model):
             vals["employee_id"] = employee_id
             self.sudo().create(vals)
         return True
+
+
+class Followers(models.Model):
+    _inherit = "mail.followers"
+
+    @api.model
+    def create(self, vals):
+        """
+        Fix for IntegrityError: duplicate key value violates unique constraint
+            "mail_followers_mail_followers_res_partner_res_model_id_uniq"
+        Found on https://github.com/odoo/odoo/issues/15589#issuecomment-455635940
+        """
+        if "res_model" in vals and "res_id" in vals and "partner_id" in vals:
+            dups = self.env["mail.followers"].search(
+                [
+                    ("res_model", "=", vals.get("res_model")),
+                    ("res_id", "=", vals.get("res_id")),
+                    ("partner_id", "=", vals.get("partner_id")),
+                ]
+            )
+            if len(dups):
+                for p in dups:
+                    p.unlink()
+        res = super(Followers, self).create(vals)
+        return res

--- a/hr_timesheet_auto_creation/tests/__init__.py
+++ b/hr_timesheet_auto_creation/tests/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2016-2017 Elico Corp (https://www.elico-corp.com)
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_timesheet_auto_creation

--- a/hr_timesheet_auto_creation/tests/test_timesheet_auto_creation.py
+++ b/hr_timesheet_auto_creation/tests/test_timesheet_auto_creation.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# © 2016-2017 Elico Corp (https://www.elico-corp.com)
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests import common
+
+from datetime import datetime, timedelta
+
+
+class TestHrTimesheetSheet(common.TransactionCase):
+    def setUp(self):
+        super(TestHrTimesheetSheet, self).setUp()
+        self.env["hr.employee"].search([]).write({"user_id": False})
+        self.tms_obj = self.env["hr_timesheet_sheet.sheet"]
+        today = datetime.now()
+        self.monday = today + timedelta(days=-today.weekday())
+        self.sunday = self.monday + timedelta(days=+6)
+
+        self.user1 = self.env.ref("base.user_root").copy({"login": "test1"})
+        self.employee1 = self.env.ref("hr.employee_ngh")
+        self.employee1.user_id = self.user1.id
+        self._create_timesheet_sheet(self.employee1.id)
+
+        self.user2 = self.user1.copy({"login": "test2"})
+        self.employee2 = self.env.ref("hr.employee_vad").copy(
+            {"user_id": self.user2.id}
+        )
+
+    def _create_timesheet_sheet(self, employee_id):
+        self.tms_obj.sudo().create(
+            {
+                "name": "TMS - 1",
+                "employee_id": employee_id,
+                "date_from": self.monday.strftime("%Y-%m-%d"),
+                "date_to": self.sunday.strftime("%Y-%m-%d"),
+            }
+        )
+
+    def test_create_employee_timesheet(self):
+        """Check timesheet has been created automatically for the week."""
+        self.tms_obj.create_employee_timesheet()
+        tms = self.tms_obj.search(
+            [
+                ("employee_id", "=", self.employee2.id),
+                ("date_to", ">=", self.monday),
+                ("date_to", "<=", self.sunday),
+            ],
+            limit=1,
+        )
+        self.assertEqual(tms.employee_id, self.employee2)


### PR DESCRIPTION
Backported from https://github.com/Elico-Corp/odoo-addons/tree/10.0/hr_timesheet_auto_creation

Somehow, I couldn't migrate/backport it by following the OCA Guidelines ; the commit history differs:  I can't create a PR. 

## Help needed:
When used with demo data, the following error is launched : 
```
IntegrityError: duplicate key value violates unique constraint "mail_followers_mail_followers_res_partner_res_model_id_uniq"
DETAIL:  Key (res_model, res_id, partner_id)=(hr_timesheet_sheet.sheet, 2, 3) already exists.
```

But a `select * from mail_followers where res_id = 2 and partner_id = 3 and res_model like 'hr_timesheet_sheet.sheet'` returns 0 tuples.

The workaround is to manually create a timesheet for Administrator user (partner_id #3)

Works perfectly without demo data.
# EDIT 04/12/19 : 
Applied this fix : https://github.com/odoo/odoo/issues/15589#issuecomment-455635940