### PR TITLE
[9.0] hr_timesheet_default_analytic_account

### DIFF
--- a/hr_timesheet_default_analytic_account/__init__.py
+++ b/hr_timesheet_default_analytic_account/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/hr_timesheet_default_analytic_account/__openerp__.py
+++ b/hr_timesheet_default_analytic_account/__openerp__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Default analytic accounts upon timesheet creation",
+    "version": "9.0.1.0.0",
+    "category": "Human Resources",
+    "summary": """
+    When creating a timesheet, adds for the period analytical lines linked to an employee's default analytic accounts
+    """,
+    "author": "Coop IT Easy SCRLfs, Odoo Community Association (OCA)",
+    "website": "www.coopiteasy.be",
+    "license": "AGPL-3",
+    "depends": ["hr_timesheet_sheet"],
+    "data": ["views/hr_employee_view.xml"],
+    "demo": ["demo/default_analytic_account_demo.xml"],
+    "installable": True,
+}

--- a/hr_timesheet_default_analytic_account/demo/default_analytic_account_demo.xml
+++ b/hr_timesheet_default_analytic_account/demo/default_analytic_account_demo.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="hr.employee_fp" model="hr.employee">
+            <field name="analytic_account_ids" eval="[
+                (4, (ref('analytic.analytic_administratif'))),
+                (4, (ref('analytic.analytic_commercial_marketing'))),
+            ]"/>
+        </record>
+
+        <record id="hr.employee_qdp" model="hr.employee">
+            <field name="analytic_account_ids" eval="[
+                (4, (ref('analytic.analytic_administratif'))),
+                (4, (ref('analytic.analytic_internal'))),
+            ]"/>
+        </record>
+    </data>
+</odoo>

--- a/hr_timesheet_default_analytic_account/models/__init__.py
+++ b/hr_timesheet_default_analytic_account/models/__init__.py
@@ -1,0 +1,3 @@
+from . import account_analytic_account
+from . import hr_employee
+from . import hr_timesheet_sheet

--- a/hr_timesheet_default_analytic_account/models/account_analytic_account.py
+++ b/hr_timesheet_default_analytic_account/models/account_analytic_account.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import time
+from openerp import models, api, fields
+
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"
+
+    analytic_account_ids = fields.Many2many(
+        comodel_name="account.analytic.account", string="Analytic Accounts"
+    )

--- a/hr_timesheet_default_analytic_account/models/hr_employee.py
+++ b/hr_timesheet_default_analytic_account/models/hr_employee.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import time
+from openerp import models, api, fields
+
+
+class AccountAnalyticAccount(models.Model):
+    _inherit = "account.analytic.account"
+
+    employee_ids = fields.Many2many(
+        comodel_name="hr.employee", string="Employees"
+    )

--- a/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
@@ -30,7 +30,7 @@ class HrTimesheetSheet(models.Model):
             "amount": 0,
             "date": date,
             "is_timesheet": "True",
-            "name": "",
+            "name": "/",
             "sheet_id": sheet_id,
             "unit_amount": 0,
             "user_id": user_id.id,

--- a/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
@@ -27,7 +27,7 @@ class HrTimesheetSheet(models.Model):
     def _prepare_analytic_line(self, date, account, sheet_id, user_id):
         return {
             "account_id": account.id,
-            "amount": 0,
+            "amount": 0.0,
             "date": date,
             "is_timesheet": "True",
             "name": "/",

--- a/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import datetime, timedelta
+
+from openerp import api, fields, models, _
+
+
+class HrTimesheetSheet(models.Model):
+    _inherit = "hr_timesheet_sheet.sheet"
+
+    def get_number_days_between_dates(self, date_from, date_to):
+        """
+        Returns number of days between two dates
+        @param date_from: string object
+        @param date_to: string object
+        @return: integer
+        """
+        datetime_from = datetime.strptime(date_from, "%Y-%m-%d")
+        datetime_to = datetime.strptime(date_to, "%Y-%m-%d")
+        difference = datetime_to - datetime_from
+        # return result and add a day
+        return difference.days + 1
+
+    def _prepare_analytic_line(self, date, account, sheet_id, user_id):
+        return {
+            "account_id": account.id,
+            "amount": 0,
+            "date": date,
+            "is_timesheet": "True",
+            "name": "",
+            "sheet_id": sheet_id,
+            "unit_amount": 0,
+            "user_id": user_id.id,
+        }
+
+    @api.model
+    def create(self, vals):
+        res = super(HrTimesheetSheet, self).create(vals)
+
+        date_from = res["date_from"]
+        date_to = res["date_to"]
+        employee_id = res["employee_id"]
+        sheet_id = res["id"]
+
+        days = self.get_number_days_between_dates(date_from, date_to)
+        for day in range(days):
+            datetime_current = (
+                datetime.strptime(date_from, "%Y-%m-%d") + timedelta(days=day)
+            ).strftime("%Y-%m-%d")
+            for account in employee_id.analytic_account_ids:
+                aal_dict = self._prepare_analytic_line(
+                    datetime_current, account, sheet_id, employee_id.user_id
+                )
+                res.write({"timesheet_ids": [(0, 0, aal_dict)]})
+        return res

--- a/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_default_analytic_account/models/hr_timesheet_sheet.py
@@ -38,12 +38,12 @@ class HrTimesheetSheet(models.Model):
 
     @api.model
     def create(self, vals):
-        res = super(HrTimesheetSheet, self).create(vals)
+        ts = super(HrTimesheetSheet, self).create(vals)
 
-        date_from = res["date_from"]
-        date_to = res["date_to"]
-        employee_id = res["employee_id"]
-        sheet_id = res["id"]
+        date_from = ts.date_from
+        date_to = ts.date_to
+        employee_id = ts.employee_id
+        sheet_id = ts.id
 
         days = self.get_number_days_between_dates(date_from, date_to)
         for day in range(days):
@@ -54,5 +54,5 @@ class HrTimesheetSheet(models.Model):
                 aal_dict = self._prepare_analytic_line(
                     datetime_current, account, sheet_id, employee_id.user_id
                 )
-                res.write({"timesheet_ids": [(0, 0, aal_dict)]})
-        return res
+                ts.write({"timesheet_ids": [(0, 0, aal_dict)]})
+        return ts

--- a/hr_timesheet_default_analytic_account/tests/__init__.py
+++ b/hr_timesheet_default_analytic_account/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_timesheet_creation

--- a/hr_timesheet_default_analytic_account/tests/test_timesheet_creation.py
+++ b/hr_timesheet_default_analytic_account/tests/test_timesheet_creation.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openerp.tests.common import TransactionCase
+from openerp.exceptions import Warning as UserError
+
+
+class TestHrTimesheetDefaultAnalyticAccount(TransactionCase):
+    def setUp(self):
+        super(TestHrTimesheetDefaultAnalyticAccount, self).setUp()
+
+        # analytic accounts
+        self.analytic_account_01 = self.env["account.analytic.account"].create(
+            {"name": "Analytic Account 01"}
+        )
+        self.analytic_account_02 = self.env["account.analytic.account"].create(
+            {"name": "Analytic Account 02"}
+        )
+
+    def test_timesheet_creation_fail_linked_employee(self):
+        # unlinked employee
+        unlinked_employee_dict = {"name": "Unlinked Employee"}
+        unlinked_employee = self.env["hr.employee"].create(
+            unlinked_employee_dict
+        )
+
+        ts_unlinked_employee_dict = {
+            "employee_id": unlinked_employee.id,
+            "date_from": "2019-12-09",
+            "date_to": "2019-12-15",
+        }
+        with self.assertRaises(UserError):
+            self.env["hr_timesheet_sheet.sheet"].create(
+                ts_unlinked_employee_dict
+            )
+
+    def test_timesheet_creation_01(self):
+        # user
+        user_01_dict = {
+            "name": "User 1",
+            "login": "user1",
+            "password": "password",
+        }
+        user_01 = self.env["res.users"].create(user_01_dict)
+
+        # employee
+        employee_01_dict = {
+            "name": "Employee 1",
+            "user_id": user_01.id,
+            "address_id": user_01.partner_id.id,
+        }
+        employee_01 = (
+            self.env["hr.employee"]
+            .with_context(mail_create_nosubscribe=True)
+            .create(employee_01_dict)
+        )
+
+        # timesheet
+        ts_01_dict = {
+            "employee_id": employee_01.id,
+            "date_from": "2019-12-09",
+            "date_to": "2019-12-15",
+        }
+        ts_01 = self.env["hr_timesheet_sheet.sheet"].create(ts_01_dict)
+
+        self.assertEqual(len(ts_01.timesheet_ids), 0)
+
+    def test_timesheet_creation_02(self):
+        # user
+        user_02_dict = {
+            "name": "User 2",
+            "login": "user2",
+            "password": "password",
+        }
+        user_02 = self.env["res.users"].create(user_02_dict)
+
+        # employee
+        employee_02_dict = {
+            "name": "Employee 2",
+            "user_id": user_02.id,
+            "address_id": user_02.partner_id.id,
+            "analytic_account_ids": [
+                (
+                    6,
+                    0,
+                    [self.analytic_account_01.id, self.analytic_account_02.id],
+                )
+            ],
+        }
+        employee_02 = (
+            self.env["hr.employee"]
+            .with_context(mail_create_nosubscribe=True)
+            .create(employee_02_dict)
+        )
+
+        # timesheet
+        ts_02_dict = {
+            "employee_id": employee_02.id,
+            "date_from": "2019-12-09",
+            "date_to": "2019-12-15",
+        }
+        ts_02 = self.env["hr_timesheet_sheet.sheet"].create(ts_02_dict)
+
+        self.assertEqual(len(ts_02.timesheet_ids), 14)

--- a/hr_timesheet_default_analytic_account/views/hr_employee_view.xml
+++ b/hr_timesheet_default_analytic_account/views/hr_employee_view.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_timesheet_default_analytic_account_view_employee_form" model="ir.ui.view">
+        <field name="name">hr.employee.view.form</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.view_employee_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='public']" position="after">
+                <page string="Timesheet">
+                    <group>
+                        <group string="Default Analytic Accounts">
+                            <field name="analytic_account_ids" widget="many2many_tags"/>
+                        </group>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
When creating a timesheet, adds for the period analytical lines linked to an employee's default analytic accounts.