### PR TITLE
[FIX] hr_timesheet_holiday: assign aal over leave range

### DIFF
--- a/hr_timesheet_holiday/models/hr_holidays.py
+++ b/hr_timesheet_holiday/models/hr_holidays.py
@@ -119,7 +119,8 @@ class HrHolidays(models.Model):
 
             # Add analytic lines for these leave hours
             dt_from = fields.Datetime.from_string(leave.date_from)
-            for day in range(abs(int(round(leave.number_of_days)))):
+            dt_to = fields.Datetime.from_string(leave.date_to)
+            for day in range((dt_to - dt_from).days + 1):
                 dt_current = dt_from + timedelta(days=day)
 
                 # get hours per working day


### PR DESCRIPTION
**before**: iteration over each day for `leave.number_of_days ` without skipping non-working day.

For example: to assign a leave from 16/01 to 22/01, the loop iterates over 16-20/1:
- it does not assign aal on we
- but it does go until the 22nd

**after**: iterate over the entire leave range.