### PR TITLE
[IMP] hr_timesheet_overtime: daily and rate management

### DIFF
--- a/hr_timesheet_overtime/__openerp__.py
+++ b/hr_timesheet_overtime/__openerp__.py
@@ -13,8 +13,9 @@
     "license": "AGPL-3",
     "depends": ["hr_contract", "hr_timesheet_sheet"],
     "data": [
-        "views/hr_timesheet_sheet_view.xml",
         "views/hr_employee_view.xml",
+        "views/hr_timesheet_sheet_view.xml",
+        "views/resource_view.xml",
     ],
     "demo": ["demo/hr_contract_demo.xml"],
     "installable": True,

--- a/hr_timesheet_overtime/__openerp__.py
+++ b/hr_timesheet_overtime/__openerp__.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Coop IT Easy SCRLfs
+# Copyright 2020 Coop IT Easy SCRLfs
 #   - Vincent Van Rossem <vincent@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 {
     "name": "Timesheet/Contract - Overtime",
     "version": "9.0.1.0.0",
@@ -13,6 +12,7 @@
     "license": "AGPL-3",
     "depends": ["hr_contract", "hr_timesheet_sheet"],
     "data": [
+        "security/ir.model.access.csv",
         "views/hr_employee_view.xml",
         "views/hr_timesheet_sheet_view.xml",
         "views/resource_view.xml",

--- a/hr_timesheet_overtime/demo/hr_contract_demo.xml
+++ b/hr_timesheet_overtime/demo/hr_contract_demo.xml
@@ -103,7 +103,7 @@
             <field name="type_id" ref="hr_contract.hr_contract_type_emp"/>
             <field name="working_hours" ref="working_hours_part_time1"/>
             <field name="wage" eval="0.0"/>
-            <field name="date_start" eval="time.strftime('%Y-%m')+'-1'"/>
+            <field name="date_start" eval="time.strftime('%Y')+'-01-01'"/>
             <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
         </record>
 
@@ -115,7 +115,7 @@
             <field name="type_id" ref="hr_contract.hr_contract_type_emp"/>
             <field name="working_hours" ref="working_hours_part_time2"/>
             <field name="wage" eval="0.0"/>
-            <field name="date_start" eval="time.strftime('%Y-%m')+'-1'"/>
+            <field name="date_start" eval="time.strftime('%Y')+'-01-01'"/>
             <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
         </record>
 

--- a/hr_timesheet_overtime/demo/hr_contract_demo.xml
+++ b/hr_timesheet_overtime/demo/hr_contract_demo.xml
@@ -1,123 +1,125 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <data noupdate="1">
+<!--
+     Copyright 2020 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
+<odoo noupdate="1">
 
-        <!-- Part time-->
-        <record id="working_hours_part_time1" model="resource.calendar">
-            <field name="name">4/5</field>
-        </record>
+    <!-- Part time-->
+    <record id="working_hours_part_time1" model="resource.calendar">
+        <field name="name">4/5</field>
+    </record>
 
-        <record id="working_hours_part_time2" model="resource.calendar">
-            <field name="name">1/5</field>
-        </record>
+    <record id="working_hours_part_time2" model="resource.calendar">
+        <field name="name">1/5</field>
+    </record>
 
-        <!-- Working Hours 4/5 -->
-        <record model="resource.calendar.attendance" id="calendar_attendance_pt_mon1">
-            <field name="name">Monday morning</field>
-            <field name="dayofweek">0</field>
-            <field name="hour_from">09</field>
-            <field name="hour_to">13</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <!-- Working Hours 4/5 -->
+    <record model="resource.calendar.attendance" id="calendar_attendance_pt_mon1">
+        <field name="name">Monday morning</field>
+        <field name="dayofweek">0</field>
+        <field name="hour_from">09</field>
+        <field name="hour_to">13</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_mon2">
-            <field name="name">Monday afternoon</field>
-            <field name="dayofweek">0</field>
-            <field name="hour_from">14</field>
-            <field name="hour_to">18</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_mon2">
+        <field name="name">Monday afternoon</field>
+        <field name="dayofweek">0</field>
+        <field name="hour_from">14</field>
+        <field name="hour_to">18</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_pt_tue1">
-            <field name="name">Tuesday morning</field>
-            <field name="dayofweek">1</field>
-            <field name="hour_from">09</field>
-            <field name="hour_to">13</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_pt_tue1">
+        <field name="name">Tuesday morning</field>
+        <field name="dayofweek">1</field>
+        <field name="hour_from">09</field>
+        <field name="hour_to">13</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_tue2">
-            <field name="name">Tuesday afternoon</field>
-            <field name="dayofweek">1</field>
-            <field name="hour_from">14</field>
-            <field name="hour_to">18</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_tue2">
+        <field name="name">Tuesday afternoon</field>
+        <field name="dayofweek">1</field>
+        <field name="hour_from">14</field>
+        <field name="hour_to">18</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_pt_wed1">
-            <field name="name">Wednesday morning</field>
-            <field name="dayofweek">2</field>
-            <field name="hour_from">09</field>
-            <field name="hour_to">13</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_pt_wed1">
+        <field name="name">Wednesday morning</field>
+        <field name="dayofweek">2</field>
+        <field name="hour_from">09</field>
+        <field name="hour_to">13</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_wed2">
-            <field name="name">Wednesday afternoon</field>
-            <field name="dayofweek">2</field>
-            <field name="hour_from">14</field>
-            <field name="hour_to">18</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_wed2">
+        <field name="name">Wednesday afternoon</field>
+        <field name="dayofweek">2</field>
+        <field name="hour_from">14</field>
+        <field name="hour_to">18</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_pt_thu1">
-            <field name="name">Thursday morning</field>
-            <field name="dayofweek">3</field>
-            <field name="hour_from">09</field>
-            <field name="hour_to">13</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_pt_thu1">
+        <field name="name">Thursday morning</field>
+        <field name="dayofweek">3</field>
+        <field name="hour_from">09</field>
+        <field name="hour_to">13</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_thu2">
-            <field name="name">Thursday afternoon</field>
-            <field name="dayofweek">3</field>
-            <field name="hour_from">14</field>
-            <field name="hour_to">18</field>
-            <field name="calendar_id" ref="working_hours_part_time1"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_thu2">
+        <field name="name">Thursday afternoon</field>
+        <field name="dayofweek">3</field>
+        <field name="hour_from">14</field>
+        <field name="hour_to">18</field>
+        <field name="calendar_id" ref="working_hours_part_time1"/>
+    </record>
 
-        <!-- Working Hours 1/5 -->
-        <record model="resource.calendar.attendance" id="calendar_attendance_pt_fri1">
-            <field name="name">Friday morning</field>
-            <field name="dayofweek">4</field>
-            <field name="hour_from">09</field>
-            <field name="hour_to">13</field>
-            <field name="calendar_id" ref="working_hours_part_time2"/>
-        </record>
+    <!-- Working Hours 1/5 -->
+    <record model="resource.calendar.attendance" id="calendar_attendance_pt_fri1">
+        <field name="name">Friday morning</field>
+        <field name="dayofweek">4</field>
+        <field name="hour_from">09</field>
+        <field name="hour_to">13</field>
+        <field name="calendar_id" ref="working_hours_part_time2"/>
+    </record>
 
-        <record model="resource.calendar.attendance" id="calendar_attendance_fri2">
-            <field name="name">Friday afternoon</field>
-            <field name="dayofweek">4</field>
-            <field name="hour_from">14</field>
-            <field name="hour_to">18</field>
-            <field name="calendar_id" ref="working_hours_part_time2"/>
-        </record>
+    <record model="resource.calendar.attendance" id="calendar_attendance_fri2">
+        <field name="name">Friday afternoon</field>
+        <field name="dayofweek">4</field>
+        <field name="hour_from">14</field>
+        <field name="hour_to">18</field>
+        <field name="calendar_id" ref="working_hours_part_time2"/>
+    </record>
 
-        <!-- Employee's Contracts -->
+    <!-- Employee's Contracts -->
 
-        <record id="pieter_parker_contract1" model="hr.contract">
-            <field name="name">Pieter Parker Contract #1</field>
-            <field name="employee_id" ref="hr.employee_fp"/>
-            <field name="job_id" ref="hr.job_ceo"/>
-            <field name="department_id" ref="hr.dep_management"/>
-            <field name="type_id" ref="hr_contract.hr_contract_type_emp"/>
-            <field name="working_hours" ref="working_hours_part_time1"/>
-            <field name="wage" eval="0.0"/>
-            <field name="date_start" eval="time.strftime('%Y')+'-01-01'"/>
-            <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
-        </record>
+    <record id="pieter_parker_contract1" model="hr.contract">
+        <field name="name">Pieter Parker Contract #1</field>
+        <field name="employee_id" ref="hr.employee_fp"/>
+        <field name="job_id" ref="hr.job_ceo"/>
+        <field name="department_id" ref="hr.dep_management"/>
+        <field name="type_id" ref="hr_contract.hr_contract_type_emp"/>
+        <field name="working_hours" ref="working_hours_part_time1"/>
+        <field name="wage" eval="0.0"/>
+        <field name="date_start" eval="time.strftime('%Y')+'-01-01'"/>
+        <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
+    </record>
 
-        <record id="pieter_parker_contract2" model="hr.contract">
-            <field name="name">Pieter Parker Contract #2</field>
-            <field name="employee_id" ref="hr.employee_fp"/>
-            <field name="job_id" ref="hr.job_ceo"/>
-            <field name="department_id" ref="hr.dep_management"/>
-            <field name="type_id" ref="hr_contract.hr_contract_type_emp"/>
-            <field name="working_hours" ref="working_hours_part_time2"/>
-            <field name="wage" eval="0.0"/>
-            <field name="date_start" eval="time.strftime('%Y')+'-01-01'"/>
-            <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
-        </record>
+    <record id="pieter_parker_contract2" model="hr.contract">
+        <field name="name">Pieter Parker Contract #2</field>
+        <field name="employee_id" ref="hr.employee_fp"/>
+        <field name="job_id" ref="hr.job_ceo"/>
+        <field name="department_id" ref="hr.dep_management"/>
+        <field name="type_id" ref="hr_contract.hr_contract_type_emp"/>
+        <field name="working_hours" ref="working_hours_part_time2"/>
+        <field name="wage" eval="0.0"/>
+        <field name="date_start" eval="time.strftime('%Y')+'-01-01'"/>
+        <field name="date_end" eval="time.strftime('%Y')+'-12-31'"/>
+    </record>
 
-    </data>
 </odoo>

--- a/hr_timesheet_overtime/models/__init__.py
+++ b/hr_timesheet_overtime/models/__init__.py
@@ -1,2 +1,5 @@
+from . import account_analytic_line
 from . import hr_employee
 from . import hr_timesheet_sheet
+from . import resource_overtime
+from . import resource_overtime_rate

--- a/hr_timesheet_overtime/models/account_analytic_line.py
+++ b/hr_timesheet_overtime/models/account_analytic_line.py
@@ -31,7 +31,7 @@ class AnalyticLine(models.Model):
         """
         Update values if date or unit_amount fields have changed
         """
-        if values.get("date") or values.get("unit_amount"):
+        if "date" in values or "unit_amount" in values:
             date = values.get("date", self.date)
             unit_amount = values.get("unit_amount", self.unit_amount)
 

--- a/hr_timesheet_overtime/models/account_analytic_line.py
+++ b/hr_timesheet_overtime/models/account_analytic_line.py
@@ -1,0 +1,41 @@
+import logging
+
+from openerp import models, fields, api
+
+_logger = logging.getLogger(__name__)
+
+
+class AnalyticLine(models.Model):
+    """
+    Apply on account analytic lines the rate defined in resource.overtime.rate
+    """
+
+    _inherit = "account.analytic.line"
+
+    @api.model
+    def create(self, values):
+        self._update_values(values)
+        return super(AnalyticLine, self).create(values)
+
+    @api.multi
+    def write(self, values):
+        self._update_values(values)
+        return super(AnalyticLine, self).write(values)
+
+    @api.model
+    def _update_values(self, values):
+        if values.get("date") or values.get("unit_amount"):
+            date = values.get("date")
+            unit_amount = values.get("unit_amount", self.unit_amount)
+
+            # rate management
+            weekday = fields.Date.from_string(date).weekday()
+            rate = (
+                self.env["resource.overtime.rate"]
+                .search([("dayofweek", "=", weekday)], limit=1)
+                .rate
+                or 1.0
+            )
+
+            # update
+            values["unit_amount"] = unit_amount * rate

--- a/hr_timesheet_overtime/models/account_analytic_line.py
+++ b/hr_timesheet_overtime/models/account_analytic_line.py
@@ -32,7 +32,7 @@ class AnalyticLine(models.Model):
         Update values if date or unit_amount fields have changed
         """
         if values.get("date") or values.get("unit_amount"):
-            date = values.get("date")
+            date = values.get("date", self.date)
             unit_amount = values.get("unit_amount", self.unit_amount)
 
             # rate management

--- a/hr_timesheet_overtime/models/account_analytic_line.py
+++ b/hr_timesheet_overtime/models/account_analytic_line.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import logging
 
 from openerp import models, fields, api
@@ -24,6 +28,9 @@ class AnalyticLine(models.Model):
 
     @api.model
     def _update_values(self, values):
+        """
+        Update values if date or unit_amount fields have changed
+        """
         if values.get("date") or values.get("unit_amount"):
             date = values.get("date")
             unit_amount = values.get("unit_amount", self.unit_amount)

--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Coop IT Easy SCRLfs
+# Copyright 2020 Coop IT Easy SCRLfs
 #   - Vincent Van Rossem <vincent@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import time
+
 from openerp import models, api, fields
 
 
 class HrEmployee(models.Model):
     _inherit = "hr.employee"
 
+    # Numeric fields
     initial_overtime = fields.Float(
         string="Initial Overtime",
         default=0.0,
         help="Initial Overtime to start Overtime Start Date with",
     )
-
     total_overtime = fields.Float(
         string="Total Overtime",
         default=0.0,
@@ -23,6 +24,7 @@ class HrEmployee(models.Model):
         help="Total Overtime since Overtime Start Date",
     )
 
+    # Date fields
     overtime_start_date = fields.Date(
         string="Overtime Start Date",
         required=True,

--- a/hr_timesheet_overtime/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_overtime/models/hr_timesheet_sheet.py
@@ -69,10 +69,10 @@ class HrTimesheetSheet(models.Model):
         for sheet in self:
             ts_overtime = 0.0
             total_timesheet_period = sheet.get_total_timesheet_period()
-            for date, total_timesheet in total_timesheet_period.items():
+            for date, total_timesheet_day in total_timesheet_period.items():
                 if sheet.employee_id.overtime_start_date <= date < current_day:
                     daily_wh = sheet.get_working_hours(date)
-                    daily_overtime = total_timesheet - daily_wh
+                    daily_overtime = total_timesheet_day - daily_wh
                     ts_overtime += daily_overtime
 
             sheet.timesheet_overtime = ts_overtime

--- a/hr_timesheet_overtime/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_overtime/models/hr_timesheet_sheet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Coop IT Easy SCRLfs
+# Copyright 2020 Coop IT Easy SCRLfs
 #   - Vincent Van Rossem <vincent@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import logging
@@ -13,27 +13,25 @@ _logger = logging.getLogger(__name__)
 class HrTimesheetSheet(models.Model):
     _inherit = "hr_timesheet_sheet.sheet"
 
+    # Numeric fields
     daily_working_hours = fields.Float(
         "Daily Working Hours",
         readonly=True,
         compute="_compute_daily_working_hours",
         help="Hours to work for the current day",
     )
-
     daily_overtime = fields.Float(
         "Daily Overtime",
         readonly=True,
         compute="_compute_daily_overtime",
         help="Overtime for the current day",
     )
-
     timesheet_overtime = fields.Float(
         "Timesheet Overtime",
         readonly=True,
         compute="_compute_timesheet_overtime",
         help="Overtime for this timesheet period",
     )
-
     total_overtime = fields.Float(
         "Overtime Total",
         readonly=True,

--- a/hr_timesheet_overtime/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_overtime/models/hr_timesheet_sheet.py
@@ -70,7 +70,7 @@ class HrTimesheetSheet(models.Model):
             ts_overtime = 0.0
             total_timesheet_period = sheet.get_total_timesheet_period()
             for date, total_timesheet in total_timesheet_period.items():
-                if current_day > date >= sheet.employee_id.overtime_start_date:
+                if sheet.employee_id.overtime_start_date <= date < current_day:
                     daily_wh = sheet.get_working_hours(date)
                     daily_overtime = total_timesheet - daily_wh
                     ts_overtime += daily_overtime

--- a/hr_timesheet_overtime/models/hr_timesheet_sheet.py
+++ b/hr_timesheet_overtime/models/hr_timesheet_sheet.py
@@ -153,12 +153,10 @@ class HrTimesheetSheet(models.Model):
         @return: total of worked hours
         """
         self.ensure_one()
-        worked_hours = 0.0
         aal = self.env["account.analytic.line"].search(
             [
                 ("user_id.id", "=", self.employee_id.user_id.id),
                 ("date", "=", date),
             ]
         )
-        worked_hours += sum(line.unit_amount for line in aal)
-        return worked_hours
+        return sum(line.unit_amount for line in aal)

--- a/hr_timesheet_overtime/models/resource_overtime.py
+++ b/hr_timesheet_overtime/models/resource_overtime.py
@@ -14,8 +14,8 @@ class ResourceOvertime(models.Model):
 
     # Relational fields
     rate_ids = fields.One2many(
-        "resource.overtime.rate",
-        "overtime_id",
+        comodel_name="resource.overtime.rate",
+        inverse_name="overtime_id",
         string="Overtime Rate",
         copy=True,
     )

--- a/hr_timesheet_overtime/models/resource_overtime.py
+++ b/hr_timesheet_overtime/models/resource_overtime.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import datetime
+
+from openerp import models, api, fields
+
+
+class ResourceOvertime(models.Model):
+    _name = "resource.overtime"
+    _description = "Resource Overtime"
+
+    name = fields.Char(required=True)
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        default=lambda self: self.env["res.company"]._company_default_get(),
+    )
+    rate_ids = fields.One2many(
+        "resource.overtime.rate",
+        "overtime_id",
+        string="Overtime Rate",
+        copy=True,
+    )
+    manager = fields.Many2one(
+        "res.users",
+        string="Workgroup Manager",
+        default=lambda self: self.env.uid,
+    )
+
+    # ---------------
+    # Utility methods
+    # ---------------
+
+    @api.multi
+    def get_rate_for_weekday(self, day_dt):
+        """ Given a day datetime, return matching rate """
+        self.ensure_one()
+        weekday = day_dt.weekday()
+        rates = self.env["resource.overtime.rate"]
+
+        for rate in self.rate_ids.filtered(
+            lambda rate: int(rate.dayofweek) == weekday
+        ):
+            rates |= rate
+        return rates

--- a/hr_timesheet_overtime/models/resource_overtime.py
+++ b/hr_timesheet_overtime/models/resource_overtime.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Coop IT Easy SCRLfs
+# Copyright 2020 Coop IT Easy SCRLfs
 #   - Vincent Van Rossem <vincent@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-import datetime
-
 from openerp import models, api, fields
 
 
@@ -11,17 +9,20 @@ class ResourceOvertime(models.Model):
     _name = "resource.overtime"
     _description = "Resource Overtime"
 
+    # String fields
     name = fields.Char(required=True)
-    company_id = fields.Many2one(
-        "res.company",
-        string="Company",
-        default=lambda self: self.env["res.company"]._company_default_get(),
-    )
+
+    # Relational fields
     rate_ids = fields.One2many(
         "resource.overtime.rate",
         "overtime_id",
         string="Overtime Rate",
         copy=True,
+    )
+    company_id = fields.Many2one(
+        "res.company",
+        string="Company",
+        default=lambda self: self.env["res.company"]._company_default_get(),
     )
     manager = fields.Many2one(
         "res.users",

--- a/hr_timesheet_overtime/models/resource_overtime.py
+++ b/hr_timesheet_overtime/models/resource_overtime.py
@@ -28,20 +28,3 @@ class ResourceOvertime(models.Model):
         string="Workgroup Manager",
         default=lambda self: self.env.uid,
     )
-
-    # ---------------
-    # Utility methods
-    # ---------------
-
-    @api.multi
-    def get_rate_for_weekday(self, day_dt):
-        """ Given a day datetime, return matching rate """
-        self.ensure_one()
-        weekday = day_dt.weekday()
-        rates = self.env["resource.overtime.rate"]
-
-        for rate in self.rate_ids.filtered(
-            lambda rate: int(rate.dayofweek) == weekday
-        ):
-            rates |= rate
-        return rates

--- a/hr_timesheet_overtime/models/resource_overtime_rate.py
+++ b/hr_timesheet_overtime/models/resource_overtime_rate.py
@@ -1,0 +1,30 @@
+from openerp import models, api, fields
+
+
+class ResourceOvertimeRate(models.Model):
+    _name = "resource.overtime.rate"
+    _description = "Rate detail"
+    _order = "dayofweek"
+
+    name = fields.Char(required=True)
+    dayofweek = fields.Selection(
+        [
+            ("0", "Monday"),
+            ("1", "Tuesday"),
+            ("2", "Wednesday"),
+            ("3", "Thursday"),
+            ("4", "Friday"),
+            ("5", "Saturday"),
+            ("6", "Sunday"),
+        ],
+        "Day of Week",
+        required=True,
+        index=True,
+    )
+    rate = fields.Float("Rate", default="1.00", digits=(3, 2))
+    overtime_id = fields.Many2one(
+        "resource.overtime",
+        string="Resource's Overtime",
+        required=True,
+        ondelete="cascade",
+    )

--- a/hr_timesheet_overtime/models/resource_overtime_rate.py
+++ b/hr_timesheet_overtime/models/resource_overtime_rate.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Coop IT Easy SCRLfs
+#   - Vincent Van Rossem <vincent@coopiteasy.be>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 from openerp import models, api, fields
 
 
@@ -6,6 +10,7 @@ class ResourceOvertimeRate(models.Model):
     _description = "Rate detail"
     _order = "dayofweek"
 
+    # String fields
     name = fields.Char(required=True)
     dayofweek = fields.Selection(
         [
@@ -21,6 +26,8 @@ class ResourceOvertimeRate(models.Model):
         required=True,
         index=True,
     )
+
+    # Numeric fields
     rate = fields.Float("Rate", default="1.00", digits=(3, 2))
     overtime_id = fields.Many2one(
         "resource.overtime",

--- a/hr_timesheet_overtime/security/ir.model.access.csv
+++ b/hr_timesheet_overtime/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_resource_overtime,resource.overtime,model_resource_overtime,base.group_system,1,1,1,1
+access_resource_overtime_rate,resource.overtime.rate,model_resource_overtime_rate,base.group_system,1,1,1,1
+

--- a/hr_timesheet_overtime/security/ir.model.access.csv
+++ b/hr_timesheet_overtime/security/ir.model.access.csv
@@ -1,6 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_resource_overtime,resource.overtime,model_resource_overtime,base.group_system,1,1,1,1
-access_resource_overtime_rate,resource.overtime.rate,model_resource_overtime_rate,base.group_system,1,1,1,1
+access_resource_overtime,resource.overtime,model_resource_overtime,base.group_hr_manager,1,1,1,1
+access_resource_overtime_rate,resource.overtime.rate,model_resource_overtime_rate,base.group_hr_manager,1,1,1,1
 access_resource_overtime_rate_user,resource.overtime.rate,model_resource_overtime_rate,base.group_user,1,0,0,0
 
 

--- a/hr_timesheet_overtime/security/ir.model.access.csv
+++ b/hr_timesheet_overtime/security/ir.model.access.csv
@@ -1,4 +1,6 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_resource_overtime,resource.overtime,model_resource_overtime,base.group_system,1,1,1,1
 access_resource_overtime_rate,resource.overtime.rate,model_resource_overtime_rate,base.group_system,1,1,1,1
+access_resource_overtime_rate_user,resource.overtime.rate,model_resource_overtime_rate,base.group_user,1,0,0,0
+
 

--- a/hr_timesheet_overtime/tests/test_overtime.py
+++ b/hr_timesheet_overtime/tests/test_overtime.py
@@ -101,7 +101,7 @@ class TestOvertime(TransactionCase):
         """
         Change overtime start date
         """
-        self.employee1.write({"overtime_start_date": "2019-12-04"})
+        self.employee1.write({"overtime_start_date": "2019-12-02"})
 
         self.assertEqual(self.ts1.timesheet_overtime, 1)
         self.assertEqual(self.ts1.total_overtime, 0)

--- a/hr_timesheet_overtime/tests/test_overtime.py
+++ b/hr_timesheet_overtime/tests/test_overtime.py
@@ -43,6 +43,7 @@ class TestOvertime(TransactionCase):
             "employee_id": self.employee1.id,
             "wage": 0.0,
             "working_hours": calendar.id,
+            "date_start": "2019-01-01",
         }
 
         self.contract1 = self.env["hr.contract"].create(contract_dict)
@@ -61,7 +62,7 @@ class TestOvertime(TransactionCase):
         self.ts1 = self.env["hr_timesheet_sheet.sheet"].create(ts1_dict)
 
         # create and link aal
-        # monday
+        # monday 02/12/2019
         self.env["account.analytic.line"].create(
             {
                 "account_id": self.analytic_account_01.id,
@@ -74,7 +75,7 @@ class TestOvertime(TransactionCase):
                 "user_id": self.employee1.user_id.id,
             }
         )
-        # tuesday -> friday
+        # tuesday 03/12/2019 -> friday 06/12/2019
         for day in range(3, 7):
             self.env["account.analytic.line"].create(
                 {
@@ -158,3 +159,79 @@ class TestOvertime(TransactionCase):
 
         self.assertEqual(ts2.timesheet_overtime, -8)
         self.assertEqual(ts2.total_overtime, -7)
+
+    def test_overtime_05(self):
+        """
+        Multiple contracts
+        """
+
+        # end previous contract
+        self.contract1.date_end = "2020-01-06"
+
+        # create new contract
+        # working hours : half-time
+        calendar = self.env["resource.calendar"].create({"name": "Calendar"})
+        for day in range(5):  # from monday to friday
+            self.env["resource.calendar.attendance"].create(
+                {
+                    "name": "Attendance",
+                    "dayofweek": str(day),
+                    "hour_from": "09",
+                    "hour_to": "13",
+                    "calendar_id": calendar[0].id,
+                }
+            )
+
+        # contracts
+        contract_dict = {
+            "name": "Contract 2",
+            "employee_id": self.employee1.id,
+            "wage": 0.0,
+            "working_hours": calendar.id,
+            "date_start": "2020-01-07",
+        }
+
+        self.contract2 = self.env["hr.contract"].create(contract_dict)
+
+        # create ts
+        ts2_dict = {
+            "employee_id": self.employee1.id,
+            "date_from": "2020-01-06",
+            "date_to": "2020-01-12",
+        }
+        self.ts2 = self.env["hr_timesheet_sheet.sheet"].create(ts2_dict)
+
+        # create and link aal
+        # monday
+        self.env["account.analytic.line"].create(
+            {
+                "account_id": self.analytic_account_01.id,
+                "amount": 0.0,
+                "date": "2020-01-06",
+                "is_timesheet": "True",
+                "name": "/",
+                "sheet_id": self.ts2.id,
+                "unit_amount": 9.0,  # expected time from previous contract
+                "user_id": self.employee1.user_id.id,
+            }
+        )
+
+        # tuesday 07/01/2020 -> friday 10/01/2020
+        for day in range(7, 11):
+            self.env["account.analytic.line"].create(
+                {
+                    "account_id": self.analytic_account_01.id,
+                    "amount": 0.0,
+                    "date": Date.to_string(date(2020, 01, day)),
+                    "is_timesheet": "True",
+                    "name": "/",
+                    "sheet_id": self.ts2.id,
+                    "unit_amount": 4.0,  # expected time from new contract
+                    "user_id": self.employee1.user_id.id,
+                }
+            )
+
+        self.assertEqual(self.ts2.timesheet_overtime, 0)
+        self.assertEqual(
+            self.ts2.total_overtime, 1
+        )  # 1 hour overtime from ts1

--- a/hr_timesheet_overtime/tests/test_overtime.py
+++ b/hr_timesheet_overtime/tests/test_overtime.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 Coop IT Easy SCRLfs
+# Copyright 2020 Coop IT Easy SCRLfs
 #   - Vincent Van Rossem <vincent@coopiteasy.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-
 from openerp.tests.common import TransactionCase
 from openerp.fields import Date
 from datetime import date

--- a/hr_timesheet_overtime/views/hr_employee_view.xml
+++ b/hr_timesheet_overtime/views/hr_employee_view.xml
@@ -9,12 +9,16 @@
         <field name="model">hr.employee</field>
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='active_group']" position="after">
-                <group string="Overtime" groups="base.group_hr_user">
-                    <field name="initial_overtime" widget="float_time"/>
-                    <field name="total_overtime" widget="float_time"/>
-                    <field name="overtime_start_date"/>
-                </group>
+            <xpath expr="//notebook" position="inside">
+                <page name="overtime" string="Overtime">
+                    <group>
+                        <group name="overtime" string="Overtime" groups="base.group_hr_user">
+                            <field name="initial_overtime" widget="float_time"/>
+                            <field name="total_overtime" widget="float_time"/>
+                            <field name="overtime_start_date"/>
+                        </group>
+                    </group>
+                </page>
             </xpath>
         </field>
     </record>
@@ -25,7 +29,8 @@
         <field name="inherit_id" ref="hr.view_employee_tree"/>
         <field name="arch" type="xml">
             <field name="work_email" position="after">
-                <field name="total_overtime" widget="float_time" groups="analytic.group_analytic_accounting" type="char"/>
+                <field name="total_overtime" widget="float_time" groups="analytic.group_analytic_accounting"
+                       type="char"/>
             </field>
         </field>
     </record>

--- a/hr_timesheet_overtime/views/hr_employee_view.xml
+++ b/hr_timesheet_overtime/views/hr_employee_view.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright 2019 Coop IT Easy
+     Copyright 2020 Coop IT Easy
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 -->
 <odoo>

--- a/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
@@ -31,4 +31,10 @@
         </field>
     </record>
 
+    <menuitem name="Overtime Rate"
+              id="menu_hr_overtime_rate" sequence="100"
+              parent="hr_attendance.timesheet_menu_root"
+              groups="base.group_hr_manager"
+              action="action_resource_overtime_form"/>
+
 </odoo>

--- a/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//group/group/label[@for='date_from']" position="before">
                     <field name="daily_working_hours" widget="float_time"/>
-                    <field name="timesheet_overtime" widget="float_time"/>
+                    <field name="daily_overtime" widget="float_time"/>
                     <field name="total_overtime" widget="float_time"/>
                 </xpath>
 
@@ -24,7 +24,6 @@
             <field name="arch" type="xml">
                  <xpath expr="//field[@name='date_to']" position="after">
                      <field name="total_overtime" widget="float_time"/>
-                     <field name="timesheet_overtime" widget="float_time"/>
                 </xpath>
             </field>
         </record>

--- a/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
+++ b/hr_timesheet_overtime/views/hr_timesheet_sheet_view.xml
@@ -1,32 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2020 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
-    <data>
 
-        <record id="hr_timesheet_sheet_form" model="ir.ui.view">
-            <field name="name">hr.timesheet.sheet.form</field>
-            <field name="model">hr_timesheet_sheet.sheet</field>
-            <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//group/group/label[@for='date_from']" position="before">
-                    <field name="daily_working_hours" widget="float_time"/>
-                    <field name="daily_overtime" widget="float_time"/>
-                    <field name="total_overtime" widget="float_time"/>
-                </xpath>
+    <record id="hr_timesheet_sheet_form" model="ir.ui.view">
+        <field name="name">hr.timesheet.sheet.form</field>
+        <field name="model">hr_timesheet_sheet.sheet</field>
+        <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/group/label[@for='date_from']" position="before">
+                <field name="daily_working_hours" widget="float_time"/>
+                <field name="daily_overtime" widget="float_time"/>
+                <field name="total_overtime" widget="float_time"/>
+            </xpath>
 
-            </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="hr_timesheet_sheet_tree_simplified" model="ir.ui.view">
-            <field name="name">hr.timesheet.sheet.tree</field>
-            <field name="model">hr_timesheet_sheet.sheet</field>
-            <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_tree_simplified"/>
+    <record id="hr_timesheet_sheet_tree_simplified" model="ir.ui.view">
+        <field name="name">hr.timesheet.sheet.tree</field>
+        <field name="model">hr_timesheet_sheet.sheet</field>
+        <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_tree_simplified"/>
 
-            <field name="arch" type="xml">
-                 <xpath expr="//field[@name='date_to']" position="after">
-                     <field name="total_overtime" widget="float_time"/>
-                </xpath>
-            </field>
-        </record>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='date_to']" position="after">
+                <field name="total_overtime" widget="float_time"/>
+            </xpath>
+        </field>
+    </record>
 
-    </data>
 </odoo>

--- a/hr_timesheet_overtime/views/resource_view.xml
+++ b/hr_timesheet_overtime/views/resource_view.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="view_resource_overtime_search" model="ir.ui.view">
+        <field name="name">resource.overtime.search</field>
+        <field name="model">resource.overtime</field>
+        <field name="arch" type="xml">
+            <search string="Search Overtime Rate">
+                <field name="name" string="Overtime Rate"/>
+                <field name="manager"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+            </search>
+        </field>
+    </record>
+
+    <record id="resource_overtime_form" model="ir.ui.view">
+        <field name="name">resource.overtime.form</field>
+        <field name="model">resource.overtime</field>
+        <field name="arch" type="xml">
+            <form string="Overtime Rate">
+                <group>
+                    <field name="name"/>
+                    <field name="manager"/>
+                    <field name="company_id" groups="base.group_multi_company"/>
+                </group>
+                <field name="rate_ids"/>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_resource_overtime_tree" model="ir.ui.view">
+        <field name="name">resource.overtime.tree</field>
+        <field name="model">resource.overtime</field>
+        <field name="arch" type="xml">
+            <tree string="Overtime Rate">
+                <field name="name"/>
+                <field name="manager"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_resource_overtime_form" model="ir.actions.act_window">
+        <field name="name">Overtime Rate</field>
+        <field name="res_model">resource.overtime</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="view_id" eval="False"/>
+        <field name="search_view_id" ref="view_resource_overtime_search"/>
+        <field name="help" type="html">
+            <p class="oe_view_nocontent_create">
+                Define rate
+            </p>
+        </field>
+    </record>
+
+
+    <record id="view_resource_overtime_rate_tree" model="ir.ui.view">
+        <field name="name">resource.overtime.rate.tree</field>
+        <field name="model">resource.overtime.rate</field>
+        <field name="arch" type="xml">
+            <tree string="Overtime Rate" editable="top">
+                <field name="name"/>
+                <field name="dayofweek"/>
+                <field name="rate"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_resource_overtime_rate_form" model="ir.ui.view">
+        <field name="name">resource.overtime.rate.form</field>
+        <field name="model">resource.overtime.rate</field>
+        <field name="arch" type="xml">
+            <form string="Overtime Rate">
+                <group>
+                    <field name="name"/>
+                    <field name="dayofweek"/>
+                    <field name="rate"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <menuitem action="action_resource_overtime_form"
+              id="menu_resource_overtime"
+              parent="resource.menu_resource_config"
+              sequence="4"/>
+
+
+</odoo>

--- a/hr_timesheet_overtime/views/resource_view.xml
+++ b/hr_timesheet_overtime/views/resource_view.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2020 Coop IT Easy
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+-->
 <odoo>
 
     <record id="view_resource_overtime_search" model="ir.ui.view">
@@ -85,6 +89,5 @@
               id="menu_resource_overtime"
               parent="resource.menu_resource_config"
               sequence="4"/>
-
 
 </odoo>


### PR DESCRIPTION
- Added `daily_overtime` field and `_compute_daily_overtime` method
- Refactored `_compute_timesheet_overtime` method : it computes overtime for the timesheet period from the start date to the current date (not included)
- Refactored `get_worked_hours` method : return the total of worked hours (sum of account analytic lines) for a given date
- Removed `write_hr_employee` as the logic is now in the hr.employee model
- Removed several `store` parameter from computed fields

This has been tested by Catherine and validated for deployment