### PR TITLE
[9.0][FIX] hr_timesheet_overtime: external id - proper data files order

### DIFF
--- a/hr_timesheet_overtime/__openerp__.py
+++ b/hr_timesheet_overtime/__openerp__.py
@@ -14,8 +14,8 @@
     "data": [
         "security/ir.model.access.csv",
         "views/hr_employee_view.xml",
-        "views/hr_timesheet_sheet_view.xml",
         "views/resource_view.xml",
+        "views/hr_timesheet_sheet_view.xml",
     ],
     "demo": ["demo/hr_contract_demo.xml"],
     "installable": True,


### PR DESCRIPTION
External ID not found: `hr_timesheet_overtime.action_resource_overtime_form` declared in `resource_view.xml` and used in `hr_timesheet_sheet_view.xml` was not found since the latter was declared before the former in the `data` dictionary.