### PR TITLE
[9.0][FIX] hr_timesheet_holiday: fields.Date must contain a string

### DIFF
--- a/hr_timesheet_holiday/__openerp__.py
+++ b/hr_timesheet_holiday/__openerp__.py
@@ -12,8 +12,8 @@
     "summary": """When holidays are granted, add lines to the analytic account
         that is linked to the Leave Type""",
     "author": "Coop IT Easy SCRLfs, "
-              "Sunflower IT, Therp BV, "
-              "Odoo Community Association (OCA)",
+    "Sunflower IT, Therp BV, "
+    "Odoo Community Association (OCA)",
     "website": "www.coopiteasy.be",
     "license": "AGPL-3",
     "depends": ["hr_holidays", "hr_timesheet_sheet", "hr_contract"],

--- a/hr_timesheet_holiday/models/hr_holidays.py
+++ b/hr_timesheet_holiday/models/hr_holidays.py
@@ -134,7 +134,7 @@ class HrHolidays(models.Model):
                 if hours_per_day:
                     leave.add_timesheet_line(
                         description=leave.name or leave.holiday_status_id.name,
-                        date=dt_current,
+                        date=fields.Date.to_string(dt_current),
                         hours=hours_per_day,
                         account=account,
                     )


### PR DESCRIPTION
In the `analytic` module, model `account.analytic.line`, `date` field (type of `fields.Date`) 
has a `default=fields.Date.context_today` parameter :
`date = fields.Date('Date', required=True, index=True, default=fields.Date.context_today)`

The `context_today` static method documentation specify a `str` return type:
```
    @staticmethod
    def context_today(record, timestamp=None):
        """ Return the current date as seen in the client's timezone in a format
            fit for date fields. This method may be used to compute default
            values.

            :param datetime timestamp: optional datetime value to use instead of
                the current date and time (must be a datetime, regular dates
                can't be converted between timezones.)
            :rtype: str
        """
```

To be consistent, date MUST be a `string` and not a `datetime` object