### PR TITLE
[FIX] hr_timesheet_overtime: overtime_start_date <= sheet.date_to

### DIFF
--- a/hr_timesheet_overtime/models/hr_employee.py
+++ b/hr_timesheet_overtime/models/hr_employee.py
@@ -38,11 +38,13 @@ class HrEmployee(models.Model):
         Computes total overtime since employee's overtime start date
         """
         for employee in self:
-            sheets = self.env["hr_timesheet_sheet.sheet"].search(
-                [
-                    ("employee_id", "=", employee.id),
-                    ("date_from", ">", employee.overtime_start_date),
-                ]
+            sheets = (
+                self.env["hr_timesheet_sheet.sheet"]
+                .search([("employee_id", "=", employee.id),])
+                .filtered(
+                    lambda s: s.date_from >= employee.overtime_start_date
+                    or employee.overtime_start_date <= s.date_to
+                )
             )
             overtime = sum(sheet.timesheet_overtime for sheet in sheets)
             employee.total_overtime = employee.initial_overtime + overtime


### PR DESCRIPTION
**Task**
[Here](https://gestion.coopiteasy.be/web#id=3923&view_type=form&model=project.task&action=479)

**Situation**
An employee has an `overtime_start_date` defined on the 02/01/2020.
If a timesheet has a `date_from` (ex 30/12/2019) before the `overtime_start_date`, the timesheet is ignored.

This situation is problematic when the `overtime_start_date` is between the following timesheet period : `date_from` = 30/12/2019 and `date_to` = 05/01/2020. The timesheet shouldn't be ignored

**Before** 
The timesheets were fetched only with `date_from` > `overtime_start_date`

**After**
The timesheets are fetched with `date_from` >= `overtime_start_date` or `date_to` >= `overtime_start_date`
