### PR TITLE
[9.0][IMP] hr_timesheet_overtime: case with_context(create=True)

### DIFF
--- a/hr_timesheet_overtime/models/account_analytic_line.py
+++ b/hr_timesheet_overtime/models/account_analytic_line.py
@@ -23,7 +23,8 @@ class AnalyticLine(models.Model):
 
     @api.multi
     def write(self, values):
-        self._update_values(values)
+        if not self.env.context.get("create"):  # sale module
+            self._update_values(values)
         return super(AnalyticLine, self).write(values)
 
     @api.model


### PR DESCRIPTION
**Task**
[Here](https://gestion.coopiteasy.be/web#id=3747&view_type=form&model=project.task&action=479)

**Situation**
When module `hr_timesheet_overtime` is used along with `sale` module, `unit_amount` value is computed twice since in `sale`, method `create()` calls `write()` method with a `with_context` key `create=True`:
```python
@api.model
def create(self, values):
    line = super(AccountAnalyticLine, self).create(values)
    res = line.sudo()._get_sale_order_line(vals=values)
    line.with_context(create=True).write(res)
    line.mapped('so_line').sudo()._compute_analytic()
    return line
```

This improvement now handles this situation. It prevents the update of values when context has key `create` set to `True`